### PR TITLE
[Feat] add credentialless Meshterm status broker

### DIFF
--- a/.learnings/2026-07-28-credentialless-status-broker.md
+++ b/.learnings/2026-07-28-credentialless-status-broker.md
@@ -1,0 +1,57 @@
+---
+problem: Expose principal-scoped Meshterm status to a host without exposing the runtime-owned principal credential
+solved: 2026-07-28
+domain: local credential brokering
+---
+
+## Problem
+
+The native host CLI needed Transport v1 status, but the only suitable principal
+credential belonged inside a protected runtime. Copying the profile, expanding
+its ACL, creating another principal-wide credential, or exposing a generic
+proxy would all weaken the trust boundary.
+
+## Key Insight
+
+Keep the reusable client contract in Meshterm core and make the
+credential-bearing component a closed, status-only integration adapter.
+Filesystem socket permissions control who can connect, while Linux
+`SO_PEERCRED` supplies the identity used for authorization; request JSON never
+supplies identity or upstream authority.
+
+## Approach
+
+1. Define one versioned request and one bounded response for `status`.
+2. Make CLI broker selection explicit and prohibit credential-profile fallback.
+3. Authenticate the adapter peer before parsing, profile reads, or networking.
+4. Fix the HTTPS origin and allow only GET `/readyz` and GET `/v1/metrics`.
+5. Reject redirects and require the final URL to equal the requested URL.
+6. Reconstruct output from an exact allowlist instead of forwarding upstream
+   JSON.
+7. Apply one deadline across local reads and both upstream requests.
+8. Emit only bounded audit metadata and fail closed if auditing fails.
+9. Test malformed frames, unknown fields, redirects, origin confusion,
+   exhausted deadlines, unsupported operations, and secret-free output.
+10. Treat real Linux peer identity and namespace behavior as a deployment gate,
+    not something that can be inferred from non-Linux tests.
+
+## Gotchas
+
+- `SO_PEERCRED` reports effective UID and primary GID, not supplementary group
+  membership. The dedicated socket group and peer GID allowlist are distinct
+  controls.
+- Default HTTP clients may follow redirects; an authenticated metrics request
+  must never leave its fixed origin.
+- Giving each read or upstream request the full timeout does not create a total
+  deadline and permits slow-client resource exhaustion.
+- A server string beginning with `https://` is not necessarily an origin; reject
+  user information, paths, queries, fragments, and malformed ports.
+- Broker mode with a missing option value must fail instead of silently
+  returning to credential-backed direct mode.
+
+## Reusable Pattern
+
+WHEN a less-trusted host needs one observation backed by a more-privileged
+runtime credential, DO expose a closed capability protocol through a
+kernel-authenticated local boundary, BECAUSE moving the credential or proxying
+its full authority defeats least privilege.

--- a/.specs/credentialless-status-broker/design.md
+++ b/.specs/credentialless-status-broker/design.md
@@ -1,0 +1,433 @@
+# Credentialless Status Broker Split — Technical Design
+
+## Architecture Overview
+
+The design separates a reusable Meshterm client contract from a
+deployment-specific credential broker.
+
+Meshterm core gains a credentialless local-client path for `status`, plus a
+small, versioned protocol and contract tests. It does not implement credential
+custody, local identity policy, or container orchestration.
+
+A separately packaged integration adapter runs inside the credential owner's
+protected boundary. It authenticates the connecting peer using a kernel
+primitive, reads the existing profile in place, performs two fixed Meshterm
+requests, constructs a bounded response, and records a redacted audit event.
+
+This is a capability-narrowing adapter, not a new Transport v1 authorization
+model. The underlying credential remains principal-wide.
+
+## Actual State
+
+- `packages/cli/index.ts` loads a JSON profile containing `server` and
+  `credential` for `status`.
+- Current `status` concurrently requests unauthenticated `GET /readyz` and
+  credential-authenticated `GET /v1/metrics`.
+- `packages/server/server.ts` scopes principal metrics to the authenticated
+  recipient.
+- Transport v1 credentials authenticate a principal; they have no command or
+  endpoint scopes.
+- The current Bun socket API is not assumed to expose Linux peer UID/GID.
+- No upstream broker protocol or credentialless CLI broker mode exists.
+
+## Ideal State
+
+- A host can run native `meshterm status` without a local credential.
+- Any external runtime can implement the generic status broker contract.
+- The Kage credential remains readable only inside its current Hermes-owned
+  boundary.
+- Unauthorized or malformed calls are rejected before profile or network
+  access.
+- The adapter cannot be used for arbitrary Meshterm or HTTP operations.
+- Deployment and credential rotation remain separately approved operations.
+
+## Gap Analysis
+
+| Gap | Resolution owner |
+|---|---|
+| CLI requires a credential profile | Meshterm core: explicit broker client mode |
+| No stable local status protocol | Meshterm core: versioned closed contract |
+| No shared schema/bounds | Meshterm core: validators, types, fixtures, tests |
+| Credential must remain runtime-owned | External adapter: in-place profile access |
+| Local caller needs strong identity | External adapter: kernel peer credentials |
+| Status credential permits more than status | External adapter: fixed-operation policy |
+| Upstream responses may evolve | External adapter: validate and reconstruct allowlisted output |
+| Runtime/socket/container policy is deployment-specific | External adapter and deployment package |
+| Rollback could accidentally rotate credentials | Deployment runbook: remove integration only |
+
+## Components and Ownership
+
+| Component | Responsibility | Proposed location | Owner |
+|---|---|---|---|
+| Broker protocol types | Closed v1 request, response, and errors | `packages/client/broker.ts` | Meshterm core |
+| Broker client | Connect, frame, bound, validate, time out | `packages/client/broker.ts` | Meshterm core |
+| CLI broker mode | Explicitly select broker endpoint for `status` | `packages/cli/index.ts` | Meshterm core |
+| Contract fixtures/tests | Verify conforming and hostile broker behavior | `packages/client/broker.test.ts`, CLI tests | Meshterm core |
+| Generic protocol docs | Explain contract without runtime assumptions | `docs/STATUS_BROKER.md` | Meshterm core |
+| Credential broker server | Authenticate peer and serve exactly `status` | External integration package, path TBD | Integration owner |
+| Profile loader | Read existing runtime profile in place | External integration package | Integration owner |
+| Meshterm status adapter | Fixed readiness/metrics calls and filtering | External integration package | Integration owner |
+| Socket and audit policy | UID/GID, directory, mode, limits, audit sink | External deployment package | Integration owner |
+| Hermes/home-lab packaging | Sidecar/service/container and bind mount | External deployment package | Home-lab owner |
+
+The external package location must be selected during the adapter
+implementation approval. It must not be added to Meshterm merely for
+convenience.
+
+## Protocol Design
+
+### Transport
+
+- A local byte-stream endpoint selected explicitly by the CLI.
+- Initial supported transport: filesystem Unix-domain socket.
+- One request and one response per connection.
+- UTF-8 JSON followed by newline.
+- Maximum request and response sizes are compile-time contract constants.
+- No streaming, batching, multiplexing, compression, negotiation, or fallback.
+- The CLI closes the connection after one bounded response.
+
+The contract describes the endpoint behavior; it does not prescribe how an
+adapter discovers credentials, authorizes users, or is deployed.
+
+### Request
+
+```json
+{
+  "version": 1,
+  "request_id": "018f4f68-2dc3-7d70-9c3a-8f905f8d57d8",
+  "operation": "status"
+}
+```
+
+Rules:
+
+- `version` is exactly `1`.
+- `request_id` is generated by the CLI and must satisfy a bounded identifier
+  grammar.
+- `operation` is exactly `status`.
+- Unknown and duplicate fields are invalid.
+- No parameters object exists in v1.
+
+### Success response
+
+```json
+{
+  "version": 1,
+  "request_id": "018f4f68-2dc3-7d70-9c3a-8f905f8d57d8",
+  "ok": true,
+  "status": {
+    "ready": true,
+    "schema_version": 2,
+    "journal_mode": "wal",
+    "queue_depth": 0,
+    "active_leases": 0,
+    "acknowledged": 0,
+    "dead_letters": 0,
+    "discarded": 0,
+    "retries": 0,
+    "oldest_message_age_ms": 0,
+    "average_delivery_latency_ms": 0
+  }
+}
+```
+
+All numeric fields are finite, non-negative, bounded integers except
+`average_delivery_latency_ms`, which may be a finite, non-negative bounded
+number. Unknown fields are rejected so protocol evolution requires review.
+
+### Error response
+
+```json
+{
+  "version": 1,
+  "request_id": "018f4f68-2dc3-7d70-9c3a-8f905f8d57d8",
+  "ok": false,
+  "error": {
+    "code": "upstream_unavailable",
+    "message": "status is unavailable"
+  }
+}
+```
+
+Error codes form a small stable allowlist, such as:
+
+- `unauthorized_peer`
+- `invalid_request`
+- `unsupported_version`
+- `profile_unavailable`
+- `upstream_unavailable`
+- `upstream_unauthorized`
+- `invalid_upstream_response`
+- `audit_unavailable`
+- `internal_error`
+
+Messages are fixed, bounded, and contain no raw exception or upstream content.
+An adapter may close without a response when responding would amplify malformed
+or oversized input.
+
+## CLI Configuration
+
+Broker selection must be explicit and unambiguous. The implementation phase
+will choose one host-neutral interface, such as:
+
+```text
+meshterm status --broker-socket /run/user/1000/meshterm-status.sock
+```
+
+or an equivalent environment/config option with the same semantics.
+
+Precedence rules:
+
+1. An explicitly selected broker endpoint uses broker mode.
+2. Broker mode never reads or falls back to a credential profile.
+3. Without broker selection, existing direct credential-backed behavior remains
+   unchanged.
+4. Broker configuration contains only endpoint and safe client limits, never a
+   credential, server URL, upstream path, or authorization policy.
+
+## External Adapter Policy
+
+The reference integration adapter must:
+
+1. Accept a local connection.
+2. Obtain UID/GID from the kernel.
+3. Reject an unauthorized peer.
+4. Read and validate one bounded request.
+5. Reject anything other than protocol v1 `status`.
+6. Load the deployment-owned Meshterm origin and existing profile in place.
+7. Request `GET /readyz` without authorization.
+8. Request `GET /v1/metrics` with the runtime-owned bearer credential.
+9. Validate both response status codes, byte bounds, JSON, and schemas.
+10. Reconstruct the contract response from allowed fields.
+11. Write one redacted audit event.
+12. Return one bounded response and close.
+
+It must not accept caller-controlled URLs, paths, methods, headers, bodies,
+credentials, profile names, timeouts, filter expressions, or audit fields.
+
+## Sequence Diagram
+
+```mermaid
+sequenceDiagram
+    actor Host as "Host user"
+    participant CLI as "Meshterm CLI"
+    participant Broker as "External status broker"
+    participant Kernel as "Kernel peer identity"
+    participant Profile as "Runtime-owned profile"
+    participant Mesh as "Meshterm Transport v1"
+    participant Audit as "Adapter audit sink"
+
+    Host->>CLI: meshterm status with broker endpoint
+    CLI->>Broker: Connect and send bounded v1 status request
+    Broker->>Kernel: Obtain peer UID/GID
+    Kernel-->>Broker: Kernel-authenticated identity
+    alt peer or request invalid
+        Broker->>Audit: Record bounded rejection
+        Broker-->>CLI: Bounded error or close
+    else authorized and valid
+        Broker->>Profile: Read existing profile in place
+        par readiness
+            Broker->>Mesh: GET /readyz
+            Mesh-->>Broker: Bounded readiness response
+        and principal metrics
+            Broker->>Mesh: GET /v1/metrics with bearer credential
+            Mesh-->>Broker: Principal-scoped bounded metrics
+        end
+        Broker->>Broker: Validate and reconstruct allowlisted status
+        Broker->>Audit: Record bounded outcome without secrets
+        Broker-->>CLI: Bounded v1 status response
+        CLI-->>Host: Print validated status
+    end
+```
+
+## Trust Boundaries
+
+```text
+Host trust domain
+  credentialless Meshterm CLI
+        |
+        | dedicated Unix socket only
+        v
+Runtime trust domain
+  adapter -> protected profile -> fixed HTTPS Meshterm origin
+        |
+        `-> redacted integration-owned audit sink
+```
+
+The socket crosses trust domains. Filesystem permissions restrict discovery and
+connection; kernel peer credentials make the authorization decision. The
+request body is never identity evidence.
+
+## Feasibility Gate: Kernel Peer Identity
+
+Before adapter implementation:
+
+1. Select a Linux-capable runtime or minimal helper exposing `SO_PEERCRED`.
+2. Prove it returns the actual UID, primary GID, and any required group
+   semantics for a Unix-socket client.
+3. Test allowed UID, allowed group, unauthorized user, forged JSON identity,
+   inherited file descriptor, and container/user-namespace cases.
+4. Document whether supplementary group authorization can be evaluated
+   reliably. If not, authorize a dedicated UID or use a deployment design whose
+   kernel evidence is unambiguous.
+5. Stop if peer identity cannot be obtained before request processing.
+
+Bun Unix-socket support alone is insufficient evidence. The broker may use a
+small implementation in a runtime with direct peer-credential support while
+the Meshterm CLI and protocol remain TypeScript/Bun.
+
+## Threat Controls by Layer
+
+| Threat | Core client control | External adapter control |
+|---|---|---|
+| Host credential theft | Broker mode never reads a profile | Profile remains runtime-only |
+| Caller identity spoofing | No identity fields in request | Kernel peer credentials |
+| Generic proxy abuse | Closed one-operation schema | Fixed GET/path allowlist |
+| Oversized/slow client | Client request and response bounds | Read/deadline/concurrency limits |
+| Malicious upstream body | Strict response schema | Pre-parse byte cap and reconstruction |
+| Secret leakage | Bounded stable client errors | Redacted errors and audit |
+| Protocol downgrade | Exact version validation | Exact version validation |
+| Partial misleading status | Reject incomplete response | All-or-nothing readiness plus metrics |
+
+## Alternatives Considered
+
+### General credential-bearing broker in Meshterm core
+
+Rejected. Credential custody, peer policy, and service supervision are
+deployment concerns. A generic credential broker would expand Meshterm from
+transport into local authorization and secret-management infrastructure.
+
+### Hermes-specific broker inside Meshterm
+
+Rejected. It couples the generic transport repository to Hermes, container
+paths, bind mounts, and Ken's home-lab topology.
+
+### Copy, symlink, bind-mount, or ACL-expand the profile to the host
+
+Rejected. Each option makes the principal-wide credential host-readable and
+breaks the protected runtime boundary.
+
+### Create another credential for the Kage principal
+
+Rejected for the initial design. It does not narrow endpoint authority and
+adds another principal-wide bearer credential.
+
+### Create a separate status principal
+
+Rejected. Principal metrics are recipient-scoped, so another principal cannot
+observe the Kage mailbox metrics.
+
+### Root or Docker helper
+
+Not selected as the target architecture. It can simplify filesystem access but
+increases privilege and operational blast radius. It may be evaluated only as
+a deployment-specific fallback under separate approval.
+
+### Caller-supplied UID/GID
+
+Rejected. Request data is attacker-controlled and cannot authenticate the peer.
+
+### Generic HTTP or command passthrough
+
+Rejected. It would turn a narrowly reviewed status capability into access to
+the full principal credential authority.
+
+### Change Transport v1 to command-scoped credentials now
+
+Deferred and out of scope. It is a server authentication redesign with wider
+migration impact; this feature must not smuggle it into a local integration.
+
+## Testing Strategy
+
+### Meshterm core contract tests
+
+- Valid request/response round trip through a fake broker.
+- Missing socket and connection refusal.
+- Timeout, early close, truncated frame, multiple frames, trailing bytes.
+- Oversized request or response.
+- Invalid UTF-8/JSON, duplicate keys, unknown fields, wrong version.
+- Mismatched request identifier.
+- Invalid metric types, negative/non-finite/out-of-range values.
+- Stable redacted error rendering.
+- Proof that broker mode does not load a credential profile.
+- Regression proof for existing direct status mode.
+- Static scan proving upstream files contain no integration-specific names.
+
+### External adapter tests
+
+- Kernel peer identity feasibility matrix.
+- Authorized and unauthorized UID/GID behavior.
+- Forged request identity has no effect.
+- Invalid requests cause zero profile reads and zero network calls.
+- Only the two fixed GET requests are possible.
+- Fixed origin cannot be overridden.
+- Profile remains in place and is never logged or copied.
+- Upstream auth, timeout, TLS, malformed body, large body, and schema failures.
+- Response allowlist excludes unknown upstream fields.
+- Audit contains allowed metadata and no credential, header, payload, lease
+  token, profile content, or raw response.
+- Connection, concurrency, request, response, and deadline limits.
+- Socket ownership/mode and dedicated runtime-directory checks.
+
+### Integration tests
+
+- Native host CLI to adapter to fake Meshterm end to end.
+- Container/user-namespace peer identity behavior on the target topology.
+- Adapter restart and stale-socket recovery.
+- Runtime restart without changing the credential profile.
+- Cutover coexistence with current Hermes access.
+- Rollback leaves existing Hermes Meshterm behavior unchanged.
+
+## Operational Design
+
+### Installation boundary
+
+- Core CLI is installed independently of the external adapter.
+- The adapter receives a dedicated runtime socket directory bind mount, not a
+  runtime data or credential directory.
+- The host sees only the socket endpoint.
+- Socket ownership/group and membership changes are listed explicitly during
+  deployment review.
+
+### Cutover
+
+1. Confirm all implementation and security gates passed.
+2. Record current host CLI, runtime, profile metadata, and status behavior
+   without exposing secrets.
+3. Start the adapter with no host client enabled.
+4. Verify socket ownership, peer authorization, audit, and fixed upstream calls.
+5. Enable broker mode for host `status`.
+6. Verify native status and confirm the host has no profile access.
+7. Observe bounded logs and resource use before declaring cutover complete.
+
+### Rollback
+
+1. Disable host broker configuration.
+2. Remove host access to the dedicated socket path.
+3. Stop and remove the adapter service/sidecar.
+4. Remove only the dedicated runtime socket bind mount and directory.
+5. Verify Hermes still reads its unchanged profile and retains its existing
+   Meshterm behavior.
+6. Do not revoke, rotate, copy, or modify the credential during rollback.
+
+## Dependencies and Risks
+
+- The external adapter requires a proven Linux kernel peer-credential API.
+- Container user namespaces can change observed UID/GID semantics.
+- Supplementary group membership may not be directly available from
+  `SO_PEERCRED`; deployment policy must avoid ambiguous authorization.
+- The audit sink's failure policy must be selected and tested before deployment.
+- Closed response schemas require deliberate protocol versioning when Meshterm
+  metrics evolve.
+- Principal-scoped metrics may be misread as global health unless labeled
+  clearly.
+
+## Approval Boundaries
+
+- Approval of this document permits no source implementation.
+- Core implementation requires approval of exact Meshterm files and behavior.
+- Adapter implementation requires approval of its repository, runtime, and
+  peer-identity approach.
+- Deployment requires a reviewed target-host plan and separate approval.
+- Credential issuance, revocation, or rotation requires a later independent
+  approval.

--- a/.specs/credentialless-status-broker/requirements.md
+++ b/.specs/credentialless-status-broker/requirements.md
@@ -1,0 +1,331 @@
+# Credentialless Status Broker Split
+
+## Overview
+
+Meshterm will define a host-neutral contract that lets its native CLI request a
+bounded `status` view without reading a Meshterm principal credential. The
+credential-bearing broker and every Hermes or home-lab runtime concern remain
+in a separately owned adapter outside the Meshterm core repository.
+
+This specification covers design and planning only. It does not approve
+implementation, deployment, credential access, or credential rotation.
+
+## Product Boundary
+
+### Meshterm core owns
+
+- A versioned, host-neutral local broker protocol for exactly one operation:
+  `status`.
+- A credentialless CLI client mode that connects to an explicitly configured
+  local broker endpoint.
+- Strict request, response, error, size, and timeout contracts.
+- Protocol types, validation, contract tests, and generic documentation.
+- Fail-closed behavior when the broker is unavailable or violates the contract.
+
+### The external integration adapter owns
+
+- Access to an existing runtime-owned Meshterm profile and credential.
+- Kernel-authenticated peer identity enforcement using `SO_PEERCRED` or an
+  equivalently strong operating-system primitive.
+- UID/GID allowlists, socket ownership, group membership, and filesystem modes.
+- The allowlist of upstream Meshterm endpoints and response filtering.
+- Payload- and secret-free audit logging.
+- Hermes, home-lab, Docker, sidecar, service, bind-mount, and container policy.
+- Installation, deployment, rollback, and credential-rotation procedures.
+
+The upstream Meshterm implementation must not name or depend on Hermes,
+OpenClaw, Docker, Obsidian, Ken's home lab, a particular Linux distribution, or
+a particular container layout.
+
+## User Stories
+
+### US-1: Credentialless host status
+
+**As a** host operator
+**I want** the native Meshterm CLI to obtain a bounded status result through a
+local broker
+**So that** the host does not need read access to a principal credential
+
+**Acceptance Criteria:**
+
+- GIVEN broker mode is explicitly configured WHEN `meshterm status` runs THEN
+  the CLI sends a versioned `status` request without loading a principal
+  credential.
+- GIVEN the broker returns a valid bounded response WHEN the CLI receives it
+  THEN the CLI prints only the contract-defined status fields.
+- GIVEN broker mode is configured WHEN no credential profile exists on the host
+  THEN `meshterm status` can still succeed.
+
+### US-2: Runtime-owned credential custody
+
+**As a** runtime owner
+**I want** the broker adapter to use the runtime's existing profile in place
+**So that** the credential is not copied, moved, linked, or exposed to the host
+
+**Acceptance Criteria:**
+
+- GIVEN the adapter starts WHEN it loads credentials THEN it reads only the
+  runtime-owned profile from inside the runtime's protected boundary.
+- GIVEN a host user can invoke the CLI WHEN inspecting host-visible paths THEN
+  no credential, copied profile, symlink, or expanded profile ACL is present.
+- GIVEN the adapter is removed WHEN rollback completes THEN the original
+  runtime profile remains unchanged.
+
+### US-3: Least-capability status broker
+
+**As a** security reviewer
+**I want** the adapter to expose exactly `status`
+**So that** access to a principal-wide credential does not become a general
+Meshterm proxy
+
+**Acceptance Criteria:**
+
+- GIVEN any operation other than `status` WHEN the adapter parses the request
+  THEN it rejects the request before any network access.
+- GIVEN a valid `status` request WHEN the adapter calls Meshterm THEN it calls
+  only `GET /readyz` and `GET /v1/metrics`.
+- GIVEN a caller supplies a URL, method, path, header, body, credential, or
+  passthrough argument WHEN validation runs THEN the adapter rejects it.
+
+### US-4: Authenticated local caller
+
+**As a** runtime owner
+**I want** local callers authorized by kernel-provided identity
+**So that** socket possession alone or caller-controlled JSON cannot grant
+access
+
+**Acceptance Criteria:**
+
+- GIVEN a new connection WHEN the adapter accepts it THEN it obtains peer
+  identity from `SO_PEERCRED` or an equivalently strong kernel primitive.
+- GIVEN the kernel peer UID/GID is not authorized WHEN a request arrives THEN
+  the adapter rejects it before profile access and network access.
+- GIVEN a request claims an allowed UID/GID in its content WHEN the kernel peer
+  is unauthorized THEN the adapter ignores the claim and rejects the request.
+
+### US-5: Safe observability
+
+**As a** home-lab operator
+**I want** bounded status and audit output
+**So that** failures can be diagnosed without exposing credentials or message
+content
+
+**Acceptance Criteria:**
+
+- GIVEN a completed or rejected request WHEN the adapter writes an audit event
+  THEN the event contains only timestamp, request identifier, peer identity,
+  operation, outcome, duration, and a bounded reason code.
+- GIVEN any upstream response or exception WHEN logging occurs THEN logs contain
+  no credential, authorization header, profile content, payload, message body,
+  lease token, or raw upstream response.
+- GIVEN an upstream error WHEN the adapter responds THEN it returns a stable,
+  bounded error code rather than the raw upstream body.
+
+## System Requirements
+
+### REQ-1: Explicit broker selection
+
+WHEN a caller selects broker mode, THE MESHTERM CLI SHALL use only the configured
+local broker endpoint and SHALL NOT fall back to loading a credential profile.
+
+### REQ-2: Existing direct mode
+
+WHEN broker mode is not selected, THE MESHTERM CLI SHALL preserve the existing
+credential-backed `status` behavior unless a separately approved change says
+otherwise.
+
+### REQ-3: One operation
+
+WHEN the upstream broker protocol receives a request, THE PROTOCOL SHALL permit
+only the literal operation `status`.
+
+### REQ-4: Versioning
+
+WHEN a request or response is exchanged, THE PROTOCOL SHALL include an explicit
+version and SHALL reject unsupported versions without downgrade.
+
+### REQ-5: Closed schemas
+
+WHEN request or response validation runs, THE VALIDATOR SHALL reject missing
+required fields, unknown fields, invalid types, duplicate requests, and data
+outside defined bounds.
+
+### REQ-6: Fixed upstream authority
+
+WHEN the external adapter handles `status`, THE ADAPTER SHALL use a
+deployment-owned Meshterm origin and runtime-owned profile that cannot be
+overridden by the caller.
+
+### REQ-7: Endpoint allowlist
+
+WHEN the adapter performs network access, THE ADAPTER SHALL issue only GET
+requests to the fixed `/readyz` and `/v1/metrics` paths.
+
+### REQ-8: Reject before effects
+
+WHEN peer authorization, framing, version, operation, or schema validation
+fails, THE ADAPTER SHALL reject the request before reading the profile or
+performing network access.
+
+### REQ-9: Kernel peer identity feasibility gate
+
+WHEN implementation planning begins, THE IMPLEMENTERS SHALL prove in an
+isolated Linux test that the chosen server runtime obtains peer UID/GID from
+`SO_PEERCRED` or an equivalent kernel primitive; IF that proof fails, THEN
+implementation SHALL stop and the runtime choice SHALL be revised.
+
+### REQ-10: Socket access policy
+
+WHEN the external adapter creates its socket, THE ADAPTER SHALL place it in a
+dedicated runtime directory with deployment-defined owner, group, and
+least-privilege mode, separate from runtime data and credential directories.
+
+### REQ-11: Resource bounds
+
+WHEN processing a connection, THE ADAPTER SHALL enforce bounded request bytes,
+response bytes, read time, upstream time, total time, concurrent connections,
+and requests per connection.
+
+### REQ-12: Response filtering
+
+WHEN upstream readiness and metrics succeed, THE ADAPTER SHALL construct a new
+response from an explicit field allowlist and SHALL NOT forward either upstream
+document verbatim.
+
+### REQ-13: Metrics semantics
+
+WHEN the adapter returns metrics, THE DOCUMENTATION SHALL state that
+`/v1/metrics` is scoped to the authenticated principal's recipient mailbox and
+does not represent global server metrics.
+
+### REQ-14: Fail-closed behavior
+
+WHEN peer authentication, parsing, profile loading, TLS, timeout, readiness,
+upstream authentication, response validation, filtering, or output bounds fail,
+THE ADAPTER SHALL return a bounded failure and SHALL NOT return partial status.
+
+### REQ-15: Secret handling
+
+WHEN the adapter reads a credential, THE ADAPTER SHALL keep it in process memory
+only as required for the two allowed requests and SHALL NOT place it in
+arguments, environment forwarded to child processes, output, audit events, or
+host-visible files.
+
+### REQ-16: Audit contract
+
+WHEN any request reaches an authorization decision, THE ADAPTER SHALL record one
+bounded structured audit event without payloads, secrets, raw request bodies, or
+raw upstream bodies.
+
+### REQ-17: No generic proxy
+
+WHEN future operations are proposed, THE SYSTEM SHALL require a new reviewed
+protocol version and explicit product-boundary approval rather than supporting
+arbitrary paths, methods, headers, bodies, commands, or passthrough.
+
+### REQ-18: Separate approval gates
+
+WHEN the specification is approved, THE PROJECT SHALL treat core implementation,
+adapter implementation, deployment, cutover, and credential rotation as
+separate approval gates.
+
+### REQ-19: Rollback safety
+
+WHEN the integration is rolled back, THE OPERATOR SHALL be able to remove the
+host broker configuration, socket exposure, and adapter process without
+changing or revoking the runtime-owned credential.
+
+### REQ-20: Generic upstream packaging
+
+WHEN Meshterm artifacts are built or documented, THE UPSTREAM ARTIFACTS SHALL
+remain usable by any conforming broker implementation without importing or
+depending on an integration-specific package.
+
+## Threat Model
+
+### Protected assets
+
+- Runtime-owned principal credential and profile.
+- Principal-scoped mailbox metrics.
+- Meshterm server origin and TLS trust.
+- Runtime boundary, socket endpoint, and audit integrity.
+- Availability of the runtime and Meshterm service.
+
+### Adversaries and failure sources
+
+- An unauthorized local user or compromised host process.
+- An authorized group member attempting unsupported operations.
+- A malicious client sending oversized, malformed, slow, replayed, or
+  caller-identity-bearing requests.
+- A compromised or misconfigured broker attempting to become a generic proxy.
+- A malicious or faulty upstream returning oversized, malformed, or sensitive
+  data.
+- Configuration drift that exposes the socket or runtime profile.
+- Logs, crash output, process arguments, or diagnostics leaking secrets.
+
+### Required controls
+
+- Filesystem DAC plus kernel peer identity authorization.
+- Closed, versioned, single-operation protocol.
+- Reject-before-profile and reject-before-network ordering.
+- Fixed origin and endpoint allowlist.
+- Response reconstruction from an allowlist.
+- Strict byte, time, and concurrency limits.
+- Stable redacted errors and payload-free audit events.
+- Negative and fault-injection tests at both contract and integration layers.
+
+### Residual risks
+
+- Any authorized broker caller can observe the permitted Kage-scoped status.
+- A fully compromised runtime can read its own credential and bypass the broker.
+- A root-level host compromise can bypass ordinary Unix ownership boundaries.
+- The adapter narrows capability by policy; Transport v1 credentials themselves
+  remain principal-wide.
+
+These residual risks must be documented in deployment review and are not solved
+by introducing another principal or copying the existing profile.
+
+## Edge Cases and Error Handling
+
+- Broker socket missing, stale, wrong type, wrong owner, or wrong mode.
+- Peer disconnects before completing a frame.
+- Multiple frames or trailing bytes are received on a one-request connection.
+- Unsupported protocol version or unknown field is received.
+- Kernel peer identity cannot be obtained.
+- Runtime profile is absent, malformed, unreadable, or unexpectedly
+  host-readable.
+- Meshterm origin is non-HTTPS outside an explicitly test-only loopback case.
+- Readiness returns non-200, invalid JSON, schema mismatch, or `ok: false`.
+- Metrics returns 401/403, invalid JSON, unknown values, negative values, or an
+  oversized body.
+- One upstream request succeeds and the other fails; the result is a complete
+  failure, not partial status.
+- Audit sink is unavailable. The deployment policy must choose and test whether
+  this is a startup failure or per-request failure; silent audit loss is not
+  allowed.
+
+## Out of Scope
+
+- A generic HTTP, RPC, shell-command, or Meshterm-command proxy.
+- Send, claim, ack, nack, history, message, dead-letter, principal, channel, or
+  operator actions.
+- Changes to Transport v1 server authentication or credential scopes.
+- Creation of a second Kage credential or a status principal.
+- Copying, moving, symlinking, exporting, or broadening ACL access to the Kage
+  profile.
+- Hermes, OpenClaw, Docker, Obsidian, or home-lab logic in Meshterm core.
+- A legacy agent, daemon, TUI, terminal injector, screen scraper, or webhook.
+- Deployment, cutover, remote host mutation, credential issuance, revocation,
+  or rotation under this specification approval.
+
+## Approval Gates
+
+1. **Phase 0 — Specification:** approval covers only these planning artifacts.
+2. **Core implementation:** requires separate approval for Meshterm source,
+   tests, and generic docs.
+3. **Adapter implementation:** requires separate approval in the chosen external
+   integration package.
+4. **Deployment and cutover:** requires separate approval after implementation
+   and security review pass.
+5. **Credential rotation drill:** requires separate approval and must not be
+   bundled with deployment.

--- a/.specs/credentialless-status-broker/tasks.md
+++ b/.specs/credentialless-status-broker/tasks.md
@@ -1,0 +1,248 @@
+# Credentialless Status Broker Split — Implementation Tasks
+
+## Summary
+
+- **Total tasks:** 18
+- **Estimated effort:** Long, split across separately approved core,
+  integration, and deployment phases
+- **Dependencies:** Approved specification; Linux peer-identity feasibility;
+  selected external adapter repository/runtime; target deployment topology
+- **Current authorization:** Phase 0 specification only
+
+No task below is authorized by approval of this file. Each phase has an
+explicit approval gate.
+
+## Phase 0: Specification Review
+
+- [ ] **TASK-0.1:** Review product ownership and out-of-scope boundaries.
+  - Files: `.specs/credentialless-status-broker/requirements.md`,
+    `.specs/credentialless-status-broker/design.md`
+  - Acceptance: Meshterm core contains no Hermes, OpenClaw, Docker, Obsidian,
+    or home-lab responsibility; the external adapter owns all runtime-specific
+    policy.
+
+- [ ] **TASK-0.2:** Approve, revise, or reject the protocol and phased plan.
+  - Files: `.specs/credentialless-status-broker/tasks.md`
+  - Acceptance: Ken explicitly identifies the next approved phase; silence or
+    general approval does not authorize implementation.
+  - Depends on: TASK-0.1
+
+## Phase 1: Kernel Identity Feasibility
+
+**Approval gate:** Requires explicit approval before experiments or files are
+created outside these specification artifacts.
+
+- [ ] **TASK-1.1:** Select candidate adapter runtime(s) with Unix peer-credential
+  support.
+  - Files: External adapter decision record, location TBD
+  - Acceptance: Candidate exposes kernel-authenticated UID/GID before request
+    processing and does not rely on request content.
+
+- [ ] **TASK-1.2:** Build an isolated `SO_PEERCRED` proof.
+  - Files: External adapter test fixture, location TBD
+  - Acceptance: Allowed UID, unauthorized UID, forged JSON identity, and
+    connection failure cases are demonstrated on Linux.
+  - Depends on: TASK-1.1
+
+- [ ] **TASK-1.3:** Validate target container/user-namespace identity semantics.
+  - Files: External adapter test fixture and decision record, location TBD
+  - Acceptance: Observed UID/GID and group policy are unambiguous on the
+    intended topology; otherwise implementation stops for redesign.
+  - Depends on: TASK-1.2
+
+## Phase 2: Meshterm Core Contract
+
+**Approval gate:** Requires explicit approval for the exact Meshterm files.
+This phase must remain independently usable by any conforming adapter.
+
+- [ ] **TASK-2.1:** Add closed broker protocol types and constants.
+  - Files: `packages/client/broker.ts`
+  - Acceptance: v1 request, success, error, byte bounds, identifier grammar, and
+    operation allowlist are represented without integration-specific imports.
+
+- [ ] **TASK-2.2:** Add strict request and response validation.
+  - Files: `packages/client/broker.ts`
+  - Acceptance: Unknown/duplicate fields, wrong versions, invalid identifiers,
+    malformed metrics, and values outside bounds fail closed.
+  - Depends on: TASK-2.1
+
+- [ ] **TASK-2.3:** Add the bounded local broker client.
+  - Files: `packages/client/broker.ts`
+  - Acceptance: One request/response per connection, deadline, byte caps,
+    request-ID matching, close behavior, and redacted failures are tested.
+  - Depends on: TASK-2.2
+
+- [ ] **TASK-2.4:** Add explicit credentialless CLI broker mode for `status`.
+  - Files: `packages/cli/index.ts`
+  - Acceptance: Broker mode never loads a profile or falls back to direct mode;
+    direct status remains unchanged when broker mode is absent.
+  - Depends on: TASK-2.3
+
+- [ ] **TASK-2.5:** Add core contract and CLI security tests.
+  - Files: `packages/client/broker.test.ts`,
+    `packages/cli/security.test.ts`
+  - Acceptance: Valid flow and malformed, oversized, slow, mismatched,
+    unavailable, and secret-leak cases pass.
+  - Depends on: TASK-2.3, TASK-2.4
+
+- [ ] **TASK-2.6:** Document the host-neutral protocol and boundary.
+  - Files: `docs/STATUS_BROKER.md`, `README.md`
+  - Acceptance: Documentation describes any conforming adapter, principal-scoped
+    metrics, limits, and explicit exclusions without home-lab/runtime coupling.
+  - Depends on: TASK-2.5
+
+## Phase 3: External Integration Adapter
+
+**Approval gate:** Requires explicit approval of the external repository,
+runtime, files, and profile access. This phase does not belong in Meshterm core.
+
+- [ ] **TASK-3.1:** Implement peer authorization and closed request parsing.
+  - Files: External adapter source/tests, location TBD
+  - Acceptance: Kernel UID/GID is checked before profile reads or network calls;
+    only v1 `status` is accepted.
+  - Depends on: TASK-1.3, TASK-2.2
+
+- [ ] **TASK-3.2:** Implement fixed readiness and metrics retrieval.
+  - Files: External adapter source/tests, location TBD
+  - Acceptance: Only fixed-origin GET `/readyz` and GET `/v1/metrics` can be
+    issued; the existing runtime profile is read in place.
+  - Depends on: TASK-3.1
+
+- [ ] **TASK-3.3:** Implement response validation, filtering, and bounds.
+  - Files: External adapter source/tests, location TBD
+  - Acceptance: Output is reconstructed from the allowlist; partial, malformed,
+    oversized, negative, non-finite, or unauthorized upstream results fail
+    closed.
+  - Depends on: TASK-3.2
+
+- [ ] **TASK-3.4:** Implement redacted audit and resource controls.
+  - Files: External adapter source/tests, location TBD
+  - Acceptance: Audit allowlist, sink-failure policy, connection limits,
+    deadlines, and secret/payload absence tests pass.
+  - Depends on: TASK-3.3
+
+## Phase 4: Packaging and Review
+
+**Approval gate:** Packaging remains external to Meshterm core and requires
+explicit approval.
+
+- [ ] **TASK-4.1:** Add dedicated socket-directory and service/sidecar packaging.
+  - Files: External deployment package, location TBD
+  - Acceptance: Only the socket directory crosses the runtime boundary; profile
+    and data directories are not mounted or made host-readable.
+  - Depends on: TASK-3.4
+
+- [ ] **TASK-4.2:** Run local end-to-end and adversarial integration tests.
+  - Files: External integration tests, location TBD
+  - Acceptance: Native CLI, adapter, fake Meshterm, peer denial, namespace,
+    restart, stale socket, audit, limits, and rollback simulations pass.
+  - Depends on: TASK-4.1
+
+- [ ] **TASK-4.3:** Complete independent boundary, code, and security reviews.
+  - Files: Review reports only; locations selected during implementation
+  - Acceptance: No unresolved release blocker; reviewers confirm there is no
+    generic proxy or credential exposure.
+  - Depends on: TASK-2.6, TASK-4.2
+
+## Phase 5: Home-Lab Deployment and Cutover
+
+**Approval gate:** Requires a separate, target-specific deployment approval.
+It must not be inferred from implementation approval.
+
+- [ ] **TASK-5.1:** Capture pre-deployment state and verify rollback inputs.
+  - Files: Deployment record outside Meshterm core
+  - Acceptance: Current CLI/runtime/service/profile metadata and recovery steps
+    are recorded without secrets.
+  - Depends on: TASK-4.3
+
+- [ ] **TASK-5.2:** Deploy adapter and socket exposure without enabling clients.
+  - Files: Remote deployment state
+  - Acceptance: Ownership, mode, peer authorization, audit, fixed endpoint
+    access, and no host profile access are verified.
+  - Depends on: TASK-5.1
+
+- [ ] **TASK-5.3:** Cut over host `status` and verify or roll back.
+  - Files: Host CLI configuration and deployment record
+  - Acceptance: Credentialless status works, metrics are labeled
+    principal-scoped, logs are clean, and existing runtime behavior remains
+    healthy; any failed gate triggers rollback.
+  - Depends on: TASK-5.2
+
+## Phase 6: Credential Rotation Drill
+
+**Approval gate:** Requires separate future approval after stable cutover.
+
+- [ ] **TASK-6.1:** Plan and execute a credential-rotation drill independently.
+  - Files: Separate rotation plan and deployment record
+  - Acceptance: New credential is verified in the protected runtime, old
+    credential is revoked only after success, no credential becomes
+    host-readable, and rollback is documented.
+  - Depends on: Stable completion of TASK-5.3 and explicit rotation approval
+
+## Verification Gates
+
+### Gate A: Specification
+
+- Exactly three files exist in
+  `.specs/credentialless-status-broker/`.
+- Requirements use EARS-style `WHEN ... THE SYSTEM SHALL ...` statements.
+- Ownership, threats, alternatives, sequence, migration, rollback, tests, and
+  separate approvals are explicit.
+- No implementation or external state change exists.
+
+### Gate B: Meshterm core implementation
+
+Run from the Meshterm repository after dependencies are installed under a
+separately approved implementation:
+
+```bash
+bun run typecheck
+bun test
+bun run build
+```
+
+Additionally prove:
+
+- broker mode performs zero credential-profile reads;
+- direct mode regression tests pass;
+- hostile broker contract tests pass;
+- upstream code/docs contain no integration-specific names or dependencies.
+
+### Gate C: External adapter implementation
+
+- Kernel peer-identity feasibility and namespace matrix pass.
+- Unauthorized and malformed requests cause zero profile and network access.
+- Endpoint and response allowlists are complete.
+- Secret/payload scanning of output, logs, audit, and process arguments is clean.
+- Resource-bound and fault-injection tests pass.
+
+### Gate D: Deployment
+
+- Reviewed socket owner/group/mode and dedicated bind mount match the approved
+  plan.
+- Host cannot read, traverse to, or receive a copy of the runtime profile.
+- Native credentialless status passes through the real socket and TLS path.
+- Existing runtime behavior remains healthy.
+- Audit and service logs contain no credential, payload, authorization header,
+  lease token, profile content, or raw upstream response.
+
+### Gate E: Rollback
+
+- Host broker mode is disabled.
+- Socket exposure and adapter are removed.
+- Runtime profile is byte-for-byte unchanged.
+- Existing runtime Meshterm behavior still works.
+- No credential issuance, revocation, or rotation occurred.
+
+## Rollback Boundary
+
+Rollback removes only:
+
+- host broker configuration;
+- host access to the dedicated socket;
+- the external adapter process/service/sidecar;
+- the dedicated runtime socket directory or bind mount.
+
+Rollback must not modify Meshterm server state, rotate or revoke credentials,
+change the runtime-owned profile, expose runtime data directories, or revive
+legacy Meshterm agents/TUI behavior.

--- a/README.md
+++ b/README.md
@@ -73,6 +73,10 @@ meshterm principals
 meshterm channel create <name> --members alice,bob
 ```
 
+`status` can also use a credentialless external status broker. See
+[the host-neutral status broker contract](docs/STATUS_BROKER.md). Meshterm core
+does not own the broker's credential custody or local authorization policy.
+
 `claim` leases messages but does not acknowledge them. Ack only after durable,
 successful processing.
 

--- a/docs/STATUS_BROKER.md
+++ b/docs/STATUS_BROKER.md
@@ -1,0 +1,78 @@
+# Credentialless status broker contract
+
+Meshterm can request principal-scoped transport status through a local broker
+without reading a principal credential. The protocol is host-neutral: any
+runtime may implement it, and Meshterm core does not own credential custody,
+local-user policy, service supervision, or container integration.
+
+```bash
+meshterm status --broker-socket /absolute/path/to/status.sock
+```
+
+`MESHTERM_BROKER_SOCKET` provides the same explicit selection for managed
+installations. Broker mode never loads or falls back to a Meshterm credential
+profile. Without broker selection, the existing direct credential-backed
+status behavior remains unchanged.
+
+## Protocol v1
+
+The transport is a local Unix-domain byte stream. Each connection carries one
+UTF-8 JSON request line and one JSON response line. Requests are limited to 512
+bytes, responses to 8192 bytes, and the default client deadline is three
+seconds.
+
+Request:
+
+```json
+{"version":1,"request_id":"UUID","operation":"status"}
+```
+
+The only operation is the literal `status`. There are no caller-controlled
+paths, methods, URLs, headers, credentials, bodies, or passthrough arguments.
+Unknown fields, duplicate fields, unsupported versions, mismatched request
+identifiers, extra frames, oversized data, and invalid metric values fail
+closed.
+
+A success response contains:
+
+```json
+{
+  "version": 1,
+  "request_id": "UUID",
+  "ok": true,
+  "status": {
+    "ready": true,
+    "schema_version": 2,
+    "journal_mode": "wal",
+    "queue_depth": 0,
+    "active_leases": 0,
+    "acknowledged": 0,
+    "dead_letters": 0,
+    "discarded": 0,
+    "retries": 0,
+    "oldest_message_age_ms": 0,
+    "average_delivery_latency_ms": 0
+  }
+}
+```
+
+Metrics describe the mailbox of the principal authenticated by the external
+broker. They are not global server metrics.
+
+## Broker requirements
+
+A conforming credential-bearing broker is external to Meshterm core. It must:
+
+- authorize the local peer using kernel-provided identity, never request JSON;
+- keep its fixed Meshterm origin and profile inaccessible to callers;
+- permit only GET `/readyz` and authenticated GET `/v1/metrics`;
+- reject invalid input before profile reads or network access;
+- validate and reconstruct the response from the exact field allowlist;
+- enforce request, response, connection, concurrency, rate, and time bounds;
+- log only bounded audit metadata without credentials, headers, payloads,
+  profile contents, lease tokens, or raw upstream bodies;
+- fail closed on authentication, audit, parsing, TLS, timeout, readiness, or
+  response-validation failures.
+
+This contract is not a generic HTTP proxy and exposes no message, delivery,
+principal, channel, dead-letter, or operator action.

--- a/integrations/hermes-status-broker/README.md
+++ b/integrations/hermes-status-broker/README.md
@@ -1,0 +1,36 @@
+# Hermes home-lab status broker adapter
+
+This deployment-specific adapter is intentionally outside Meshterm core. It
+keeps the existing Kage v1 profile inside Hermes, authenticates a host caller
+with Linux `SO_PEERCRED`, and exposes only the versioned status-broker contract.
+
+The adapter must run where the existing profile is already readable. Only its
+dedicated Unix-socket directory may be bind-mounted to the host. Never mount,
+copy, link, print, or broaden access to the profile or runtime data directory.
+
+Required launch arguments:
+
+```text
+python3 status_broker.py \
+  --socket /run/meshterm-status/status.sock \
+  --profile /opt/data/home/.meshterm/profiles/kage.json \
+  --allowed-uids HOST_UID \
+  --allowed-gids HOST_EFFECTIVE_PRIMARY_GID
+```
+
+The deployment must set the socket directory owner/group and mode before
+starting the broker. The broker creates the socket with mode `0660`, rejects
+unauthorized kernel peer identities before profile or network access, permits
+only GET `/readyz` and GET `/v1/metrics`, filters the response, and writes
+bounded JSON audit events to stdout without secrets or payloads.
+
+The dedicated socket group controls filesystem access. Linux `SO_PEERCRED`
+reports the connecting process's effective UID and primary GID, not its
+supplementary socket-group membership. Deployment must therefore authorize the
+exact host UID and observed effective primary GID independently of the
+dedicated socket group, and verify those values across the target container
+namespace before cutover.
+
+Rollback disables the host broker setting, removes the dedicated socket bind
+mount, and removes this adapter. It does not touch the existing profile or any
+Meshterm credential, principal, server data, or delivery.

--- a/integrations/hermes-status-broker/meshterm-wrapper.sh
+++ b/integrations/hermes-status-broker/meshterm-wrapper.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+set -eu
+
+export MESHTERM_BROKER_SOCKET="${MESHTERM_BROKER_SOCKET:-/home/ken/.local/run/meshterm-status/status.sock}"
+exec /home/ken/.bun/bin/bun /home/ken/meshterm-status-broker/cli/index.js "$@"

--- a/integrations/hermes-status-broker/namespace_peercheck.py
+++ b/integrations/hermes-status-broker/namespace_peercheck.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+"""One-shot Linux namespace check for Unix peer credentials."""
+
+import argparse
+import json
+import os
+import socket
+import struct
+from pathlib import Path
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--socket", required=True, type=Path)
+    args = parser.parse_args()
+    if not hasattr(socket, "SO_PEERCRED"):
+        raise RuntimeError("SO_PEERCRED unavailable")
+    if args.socket.exists():
+        args.socket.unlink()
+    with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as server:
+        server.bind(str(args.socket))
+        os.chmod(args.socket, 0o666)
+        server.listen(1)
+        connection, _ = server.accept()
+        with connection:
+            raw = connection.getsockopt(
+                socket.SOL_SOCKET,
+                socket.SO_PEERCRED,
+                struct.calcsize("3i"),
+            )
+            pid, uid, gid = struct.unpack("3i", raw)
+            print(
+                json.dumps(
+                    {"peer_pid": pid, "peer_uid": uid, "peer_gid": gid},
+                    separators=(",", ":"),
+                ),
+                flush=True,
+            )
+            connection.sendall(b"ok\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/integrations/hermes-status-broker/status_broker.py
+++ b/integrations/hermes-status-broker/status_broker.py
@@ -1,0 +1,432 @@
+#!/usr/bin/env python3
+"""Status-only Meshterm credential broker for the Hermes home-lab integration."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import socket
+import ssl
+import struct
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+import uuid
+from collections import defaultdict, deque
+from pathlib import Path
+from typing import Any
+
+VERSION = 1
+MAX_REQUEST_BYTES = 512
+MAX_UPSTREAM_BYTES = 8_192
+MAX_RESPONSE_BYTES = 8_192
+DEFAULT_TIMEOUT_SECONDS = 3.0
+BROKER_USER_AGENT = "meshterm-status-broker/1.0"
+STATUS_KEYS = (
+    "queue_depth",
+    "active_leases",
+    "acknowledged",
+    "dead_letters",
+    "discarded",
+    "retries",
+    "oldest_message_age_ms",
+    "average_delivery_latency_ms",
+)
+ERROR_MESSAGES = {
+    "unauthorized_peer": "peer is not authorized",
+    "invalid_request": "request is invalid",
+    "unsupported_version": "protocol version is unsupported",
+    "profile_unavailable": "status profile is unavailable",
+    "upstream_unavailable": "status is unavailable",
+    "upstream_unauthorized": "status authorization failed",
+    "invalid_upstream_response": "status response is invalid",
+    "audit_unavailable": "audit is unavailable",
+    "internal_error": "status is unavailable",
+}
+
+
+class BrokerFailure(Exception):
+    def __init__(self, code: str) -> None:
+        super().__init__(code)
+        self.code = code
+
+
+class RejectRedirects(urllib.request.HTTPRedirectHandler):
+    def redirect_request(self, *_args: Any, **_kwargs: Any) -> None:
+        return None
+
+
+def strict_object(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise BrokerFailure("invalid_request")
+        result[key] = value
+    return result
+
+
+def parse_id_set(value: str) -> set[int]:
+    try:
+        result = {int(item) for item in value.split(",") if item}
+    except ValueError as error:
+        raise ValueError("peer id allowlists must contain integers") from error
+    if not result or any(item < 0 for item in result):
+        raise ValueError("peer id allowlists must not be empty or negative")
+    return result
+
+
+def validate_request(data: bytes) -> dict[str, Any]:
+    if len(data) > MAX_REQUEST_BYTES or not data.endswith(b"\n"):
+        raise BrokerFailure("invalid_request")
+    try:
+        text = data[:-1].decode("utf-8", errors="strict")
+        request = json.loads(text, object_pairs_hook=strict_object)
+    except (UnicodeDecodeError, json.JSONDecodeError, BrokerFailure):
+        raise BrokerFailure("invalid_request")
+    if not isinstance(request, dict):
+        raise BrokerFailure("invalid_request")
+    if set(request) != {"version", "request_id", "operation"}:
+        raise BrokerFailure("invalid_request")
+    if request["version"] != VERSION:
+        raise BrokerFailure("unsupported_version")
+    if request["operation"] != "status":
+        raise BrokerFailure("invalid_request")
+    try:
+        parsed_id = uuid.UUID(request["request_id"])
+    except (AttributeError, TypeError, ValueError):
+        raise BrokerFailure("invalid_request")
+    if str(parsed_id) != request["request_id"]:
+        raise BrokerFailure("invalid_request")
+    return request
+
+
+def load_profile(path: Path) -> tuple[str, str]:
+    try:
+        profile = json.loads(path.read_text(encoding="utf-8"))
+        server = profile["server"]
+        credential = profile["credential"]
+    except (OSError, KeyError, TypeError, json.JSONDecodeError):
+        raise BrokerFailure("profile_unavailable")
+    if not isinstance(server, str) or not isinstance(credential, str):
+        raise BrokerFailure("profile_unavailable")
+    try:
+        parsed = urllib.parse.urlsplit(server)
+        _ = parsed.port
+    except ValueError:
+        raise BrokerFailure("profile_unavailable")
+    if (
+        parsed.scheme != "https"
+        or not parsed.hostname
+        or parsed.username is not None
+        or parsed.password is not None
+        or parsed.path not in ("", "/")
+        or parsed.query
+        or parsed.fragment
+        or not credential.startswith("mtk_")
+    ):
+        raise BrokerFailure("profile_unavailable")
+    return f"https://{parsed.netloc}", credential
+
+
+def read_json_response(
+    request: urllib.request.Request,
+    timeout: float,
+) -> dict[str, Any]:
+    try:
+        opener = urllib.request.build_opener(
+            RejectRedirects(),
+            urllib.request.HTTPSHandler(context=ssl.create_default_context()),
+        )
+        with opener.open(
+            request,
+            timeout=timeout,
+        ) as response:
+            if response.geturl() != request.full_url:
+                raise BrokerFailure("upstream_unavailable")
+            data = response.read(MAX_UPSTREAM_BYTES + 1)
+    except urllib.error.HTTPError as error:
+        if error.code in (401, 403):
+            raise BrokerFailure("upstream_unauthorized")
+        raise BrokerFailure("upstream_unavailable")
+    except (OSError, TimeoutError, urllib.error.URLError):
+        raise BrokerFailure("upstream_unavailable")
+    if len(data) > MAX_UPSTREAM_BYTES:
+        raise BrokerFailure("invalid_upstream_response")
+    try:
+        value = json.loads(data, object_pairs_hook=strict_object)
+    except (
+        UnicodeDecodeError,
+        json.JSONDecodeError,
+        BrokerFailure,
+    ):
+        raise BrokerFailure("invalid_upstream_response")
+    if not isinstance(value, dict):
+        raise BrokerFailure("invalid_upstream_response")
+    return value
+
+
+def bounded_nonnegative(value: Any, *, integer: bool) -> int | float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise BrokerFailure("invalid_upstream_response")
+    if integer and not isinstance(value, int):
+        raise BrokerFailure("invalid_upstream_response")
+    if value < 0 or value > 9_007_199_254_740_991:
+        raise BrokerFailure("invalid_upstream_response")
+    if isinstance(value, float) and not (float("-inf") < value < float("inf")):
+        raise BrokerFailure("invalid_upstream_response")
+    return value
+
+
+def remaining(deadline: float) -> float:
+    value = deadline - time.monotonic()
+    if value <= 0:
+        raise BrokerFailure("upstream_unavailable")
+    return value
+
+
+def fetch_status(
+    profile_path: Path,
+    timeout: float,
+    deadline: float | None = None,
+) -> dict[str, Any]:
+    deadline = deadline if deadline is not None else time.monotonic() + timeout
+    server, credential = load_profile(profile_path)
+    ready = read_json_response(
+        urllib.request.Request(
+            f"{server}/readyz",
+            method="GET",
+            headers={"User-Agent": BROKER_USER_AGENT},
+        ),
+        remaining(deadline),
+    )
+    metrics = read_json_response(
+        urllib.request.Request(
+            f"{server}/v1/metrics",
+            method="GET",
+            headers={
+                "Authorization": f"Bearer {credential}",
+                "User-Agent": BROKER_USER_AGENT,
+            },
+        ),
+        remaining(deadline),
+    )
+    if set(ready) != {"ok", "store"} or ready["ok"] is not True:
+        raise BrokerFailure("invalid_upstream_response")
+    store = ready["store"]
+    if (
+        not isinstance(store, dict)
+        or set(store) != {"ok", "journal_mode", "schema_version"}
+        or store["ok"] is not True
+        or not isinstance(store["journal_mode"], str)
+        or len(store["journal_mode"]) > 16
+    ):
+        raise BrokerFailure("invalid_upstream_response")
+    schema_version = bounded_nonnegative(store["schema_version"], integer=True)
+    if set(metrics) != set(STATUS_KEYS):
+        raise BrokerFailure("invalid_upstream_response")
+    filtered: dict[str, Any] = {
+        "ready": True,
+        "schema_version": schema_version,
+        "journal_mode": store["journal_mode"],
+    }
+    for key in STATUS_KEYS:
+        filtered[key] = bounded_nonnegative(
+            metrics[key],
+            integer=key != "average_delivery_latency_ms",
+        )
+    return filtered
+
+
+class StatusBroker:
+    def __init__(
+        self,
+        socket_path: Path,
+        profile_path: Path,
+        allowed_uids: set[int],
+        allowed_gids: set[int],
+        timeout: float = DEFAULT_TIMEOUT_SECONDS,
+        rate_limit: int = 30,
+    ) -> None:
+        if not hasattr(socket, "SO_PEERCRED"):
+            raise RuntimeError("kernel peer credentials are unavailable")
+        if timeout <= 0 or timeout > 30:
+            raise ValueError("timeout must be greater than zero and at most 30")
+        if rate_limit < 1 or rate_limit > 10_000:
+            raise ValueError("rate limit must be between 1 and 10000")
+        self.socket_path = socket_path
+        self.profile_path = profile_path
+        self.allowed_uids = allowed_uids
+        self.allowed_gids = allowed_gids
+        self.timeout = timeout
+        self.rate_limit = rate_limit
+        self.rate_windows: dict[int, deque[float]] = defaultdict(deque)
+
+    def audit(
+        self,
+        request_id: str,
+        uid: int,
+        gid: int,
+        outcome: str,
+        reason: str,
+        started: float,
+    ) -> None:
+        event = {
+            "time": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+            "event": "meshterm.status_broker",
+            "request_id": request_id[:64],
+            "peer_uid": uid,
+            "peer_gid": gid,
+            "operation": "status",
+            "outcome": outcome,
+            "reason": reason,
+            "duration_ms": round((time.monotonic() - started) * 1000),
+        }
+        try:
+            print(json.dumps(event, separators=(",", ":")), flush=True)
+        except (OSError, ValueError):
+            raise BrokerFailure("audit_unavailable")
+
+    def rate_allowed(self, uid: int) -> bool:
+        now = time.monotonic()
+        window = self.rate_windows[uid]
+        while window and window[0] <= now - 60:
+            window.popleft()
+        if len(window) >= self.rate_limit:
+            return False
+        window.append(now)
+        return True
+
+    def peer_identity(self, connection: socket.socket) -> tuple[int, int, int]:
+        credentials = connection.getsockopt(
+            socket.SOL_SOCKET,
+            socket.SO_PEERCRED,
+            struct.calcsize("3i"),
+        )
+        return struct.unpack("3i", credentials)
+
+    def response(self, request_id: str, status: dict[str, Any]) -> bytes:
+        return (
+            json.dumps(
+                {
+                    "version": VERSION,
+                    "request_id": request_id,
+                    "ok": True,
+                    "status": status,
+                },
+                separators=(",", ":"),
+                allow_nan=False,
+            ).encode()
+            + b"\n"
+        )
+
+    def error_response(self, request_id: str, code: str) -> bytes:
+        return (
+            json.dumps(
+                {
+                    "version": VERSION,
+                    "request_id": request_id,
+                    "ok": False,
+                    "error": {"code": code, "message": ERROR_MESSAGES[code]},
+                },
+                separators=(",", ":"),
+            ).encode()
+            + b"\n"
+        )
+
+    def handle(self, connection: socket.socket) -> None:
+        started = time.monotonic()
+        deadline = started + self.timeout
+        request_id = "unknown"
+        uid = gid = -1
+        try:
+            connection.settimeout(remaining(deadline))
+            _pid, uid, gid = self.peer_identity(connection)
+            if uid not in self.allowed_uids or gid not in self.allowed_gids:
+                raise BrokerFailure("unauthorized_peer")
+            if not self.rate_allowed(uid):
+                raise BrokerFailure("invalid_request")
+            data = b""
+            while not data.endswith(b"\n") and len(data) <= MAX_REQUEST_BYTES:
+                connection.settimeout(remaining(deadline))
+                chunk = connection.recv(min(256, MAX_REQUEST_BYTES + 1 - len(data)))
+                if not chunk:
+                    break
+                data += chunk
+            request = validate_request(data)
+            request_id = request["request_id"]
+            status = fetch_status(self.profile_path, self.timeout, deadline)
+            self.audit(request_id, uid, gid, "success", "ok", started)
+            response = self.response(request_id, status)
+        except BrokerFailure as error:
+            try:
+                self.audit(request_id, uid, gid, "rejected", error.code, started)
+                response = self.error_response(request_id, error.code)
+            except BrokerFailure:
+                return
+        except Exception:
+            try:
+                self.audit(request_id, uid, gid, "failed", "internal_error", started)
+                response = self.error_response(request_id, "internal_error")
+            except BrokerFailure:
+                return
+        if len(response) <= MAX_RESPONSE_BYTES:
+            try:
+                connection.sendall(response)
+            except OSError:
+                pass
+
+    def serve_forever(self) -> None:
+        self.socket_path.parent.mkdir(mode=0o750, parents=True, exist_ok=True)
+        directory = self.socket_path.parent.stat()
+        if directory.st_mode & 0o002:
+            raise RuntimeError("broker directory must not be world-writable")
+        if self.socket_path.exists():
+            if not self.socket_path.is_socket():
+                raise RuntimeError("broker path exists and is not a socket")
+            self.socket_path.unlink()
+        with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as server:
+            server.bind(str(self.socket_path))
+            os.chmod(self.socket_path, 0o660)
+            server.listen(8)
+            while True:
+                connection, _ = server.accept()
+                with connection:
+                    self.handle(connection)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Status-only Meshterm broker")
+    parser.add_argument("--socket", required=True, type=Path)
+    parser.add_argument("--profile", required=True, type=Path)
+    parser.add_argument(
+        "--allowed-uids",
+        default=os.environ.get("MESHTERM_STATUS_ALLOWED_UIDS", ""),
+    )
+    parser.add_argument(
+        "--allowed-gids",
+        default=os.environ.get("MESHTERM_STATUS_ALLOWED_GIDS", ""),
+    )
+    parser.add_argument("--timeout", type=float, default=DEFAULT_TIMEOUT_SECONDS)
+    parser.add_argument("--rate-limit", type=int, default=30)
+    args = parser.parse_args()
+    try:
+        broker = StatusBroker(
+            args.socket,
+            args.profile,
+            parse_id_set(args.allowed_uids),
+            parse_id_set(args.allowed_gids),
+            args.timeout,
+            args.rate_limit,
+        )
+        broker.serve_forever()
+    except (OSError, RuntimeError, ValueError) as error:
+        print(f"status broker failed: {error}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/integrations/hermes-status-broker/test_status_broker.py
+++ b/integrations/hermes-status-broker/test_status_broker.py
@@ -1,0 +1,341 @@
+import io
+import json
+import socket
+import tempfile
+import unittest
+import urllib.request
+import uuid
+from collections import defaultdict, deque
+from pathlib import Path
+from unittest.mock import patch
+
+import status_broker
+
+
+class FakeResponse:
+    def __init__(self, value, url="https://mesh.example.test"):
+        self.value = json.dumps(value).encode()
+        self.url = url
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        return None
+
+    def read(self, limit):
+        return self.value[:limit]
+
+    def geturl(self):
+        return self.url
+
+
+class RequestTests(unittest.TestCase):
+    def valid(self):
+        return (
+            json.dumps(
+                {
+                    "version": 1,
+                    "request_id": str(uuid.uuid4()),
+                    "operation": "status",
+                }
+            ).encode()
+            + b"\n"
+        )
+
+    def test_accepts_only_closed_v1_status_request(self):
+        request = status_broker.validate_request(self.valid())
+        self.assertEqual(request["operation"], "status")
+
+    def test_rejects_unknown_operation_and_fields(self):
+        for value in (
+            {"version": 1, "request_id": str(uuid.uuid4()), "operation": "send"},
+            {
+                "version": 1,
+                "request_id": str(uuid.uuid4()),
+                "operation": "status",
+                "url": "https://attacker.invalid",
+            },
+        ):
+            with self.assertRaises(status_broker.BrokerFailure):
+                status_broker.validate_request(json.dumps(value).encode() + b"\n")
+
+    def test_rejects_duplicate_fields_before_effects(self):
+        request_id = str(uuid.uuid4())
+        data = (
+            f'{{"version":1,"request_id":"{request_id}",'
+            '"operation":"status","operation":"send"}\n'
+        ).encode()
+        with self.assertRaises(status_broker.BrokerFailure):
+            status_broker.validate_request(data)
+
+    def test_rejects_oversized_or_unframed_input(self):
+        with self.assertRaises(status_broker.BrokerFailure):
+            status_broker.validate_request(b"x" * 513)
+        with self.assertRaises(status_broker.BrokerFailure):
+            status_broker.validate_request(self.valid()[:-1])
+
+
+class FakeConnection:
+    def __init__(self, request):
+        self.request = request
+        self.response = b""
+
+    def settimeout(self, _timeout):
+        pass
+
+    def recv(self, _limit):
+        request, self.request = self.request, b""
+        return request
+
+    def sendall(self, response):
+        self.response += response
+
+
+class HandleTests(unittest.TestCase):
+    def broker(self):
+        broker = object.__new__(status_broker.StatusBroker)
+        broker.socket_path = Path("/tmp/unused.sock")
+        broker.profile_path = Path("/tmp/protected-profile.json")
+        broker.allowed_uids = {1000}
+        broker.allowed_gids = {1000}
+        broker.timeout = 1
+        broker.rate_limit = 30
+        broker.rate_windows = defaultdict(deque)
+        broker.peer_identity = lambda _connection: (123, 1000, 1000)
+        return broker
+
+    @patch("status_broker.fetch_status")
+    def test_success_audit_and_response_are_filtered(self, fetch):
+        request_id = str(uuid.uuid4())
+        connection = FakeConnection(
+            json.dumps(
+                {
+                    "version": 1,
+                    "request_id": request_id,
+                    "operation": "status",
+                }
+            ).encode()
+            + b"\n"
+        )
+        fetch.return_value = {
+            "ready": True,
+            "schema_version": 2,
+            "journal_mode": "wal",
+            "queue_depth": 0,
+            "active_leases": 0,
+            "acknowledged": 1,
+            "dead_letters": 0,
+            "discarded": 0,
+            "retries": 0,
+            "oldest_message_age_ms": 0,
+            "average_delivery_latency_ms": 1.5,
+        }
+        output = io.StringIO()
+        with patch("sys.stdout", output):
+            self.broker().handle(connection)
+        audit = output.getvalue()
+        response = connection.response.decode()
+        self.assertIn('"outcome":"success"', audit)
+        self.assertIn('"ok":true', response)
+        for forbidden in ("credential", "authorization", "payload", "lease_token"):
+            self.assertNotIn(forbidden, audit.lower())
+            self.assertNotIn(forbidden, response.lower())
+
+    @patch("status_broker.fetch_status")
+    def test_unsupported_operation_fails_before_profile_or_network(self, fetch):
+        connection = FakeConnection(
+            json.dumps(
+                {
+                    "version": 1,
+                    "request_id": str(uuid.uuid4()),
+                    "operation": "send",
+                }
+            ).encode()
+            + b"\n"
+        )
+        with patch("sys.stdout", io.StringIO()):
+            self.broker().handle(connection)
+        self.assertFalse(fetch.called)
+        self.assertIn(b'"ok":false', connection.response)
+
+
+class UpstreamTests(unittest.TestCase):
+    def setUp(self):
+        self.directory = tempfile.TemporaryDirectory()
+        self.profile = Path(self.directory.name) / "kage.json"
+        self.profile.write_text(
+            json.dumps(
+                {
+                    "server": "https://mesh.example.test",
+                    "credential": "mtk_not-printed",
+                }
+            )
+        )
+
+    def tearDown(self):
+        self.directory.cleanup()
+
+    def response(self, request, **_kwargs):
+        self.assertIsInstance(request, urllib.request.Request)
+        self.assertEqual(request.get_method(), "GET")
+        self.assertEqual(
+            request.get_header("User-agent"),
+            status_broker.BROKER_USER_AGENT,
+        )
+        if request.full_url.endswith("/readyz"):
+            self.assertEqual(
+                request.full_url,
+                "https://mesh.example.test/readyz",
+            )
+            self.assertIsNone(request.get_header("Authorization"))
+            return FakeResponse(
+                {
+                    "ok": True,
+                    "store": {
+                        "ok": True,
+                        "journal_mode": "wal",
+                        "schema_version": 2,
+                    },
+                },
+                request.full_url,
+            )
+        self.assertEqual(request.full_url, "https://mesh.example.test/v1/metrics")
+        self.assertEqual(request.get_header("Authorization"), "Bearer mtk_not-printed")
+        return FakeResponse(
+            {
+                "queue_depth": 0,
+                "active_leases": 0,
+                "acknowledged": 1,
+                "dead_letters": 0,
+                "discarded": 0,
+                "retries": 0,
+                "oldest_message_age_ms": 0,
+                "average_delivery_latency_ms": 1.5,
+            },
+            request.full_url,
+        )
+
+    @patch("urllib.request.OpenerDirector.open")
+    def test_calls_only_fixed_endpoints_and_filters_response(self, open_request):
+        open_request.side_effect = self.response
+        result = status_broker.fetch_status(self.profile, 1)
+        self.assertEqual(
+            set(result),
+            {"ready", "schema_version", "journal_mode", *status_broker.STATUS_KEYS},
+        )
+        self.assertEqual(open_request.call_count, 2)
+
+    @patch("urllib.request.OpenerDirector.open")
+    def test_rejects_unknown_upstream_fields(self, open_request):
+        def response(request, **kwargs):
+            value = self.response(request, **kwargs)
+            if request.full_url.endswith("/v1/metrics"):
+                parsed = json.loads(value.value)
+                parsed["payload"] = "must-not-pass"
+                return FakeResponse(parsed, request.full_url)
+            return value
+
+        open_request.side_effect = response
+        with self.assertRaises(status_broker.BrokerFailure):
+            status_broker.fetch_status(self.profile, 1)
+
+    def test_rejects_non_origin_profile_servers(self):
+        for server in (
+            "http://mesh.example.test",
+            "https://user@mesh.example.test",
+            "https://mesh.example.test/path",
+            "https://mesh.example.test?query=1",
+            "https://mesh.example.test/#fragment",
+        ):
+            self.profile.write_text(
+                json.dumps({"server": server, "credential": "mtk_test"})
+            )
+            with self.assertRaises(status_broker.BrokerFailure):
+                status_broker.load_profile(self.profile)
+
+    @patch("urllib.request.OpenerDirector.open")
+    def test_rejects_redirected_or_changed_origins(self, open_request):
+        open_request.return_value = FakeResponse(
+            {
+                "ok": True,
+                "store": {
+                    "ok": True,
+                    "journal_mode": "wal",
+                    "schema_version": 2,
+                },
+            },
+            "https://attacker.invalid/readyz",
+        )
+        with self.assertRaises(status_broker.BrokerFailure) as failure:
+            status_broker.fetch_status(self.profile, 1)
+        self.assertEqual(failure.exception.code, "upstream_unavailable")
+        self.assertEqual(open_request.call_count, 1)
+
+    def test_redirect_handler_never_constructs_a_followup_request(self):
+        handler = status_broker.RejectRedirects()
+        self.assertIsNone(
+            handler.redirect_request(
+                urllib.request.Request("https://mesh.example.test/v1/metrics"),
+                None,
+                302,
+                "Found",
+                {},
+                "https://attacker.invalid/v1/metrics",
+            )
+        )
+
+    @patch("urllib.request.OpenerDirector.open")
+    def test_exhausted_deadline_stops_before_metrics(self, open_request):
+        open_request.side_effect = self.response
+        with patch(
+            "status_broker.time.monotonic",
+            side_effect=[10.0, 10.0, 12.0],
+        ):
+            with self.assertRaises(status_broker.BrokerFailure):
+                status_broker.fetch_status(self.profile, 1)
+        self.assertEqual(open_request.call_count, 1)
+
+
+@unittest.skipUnless(hasattr(socket, "SO_PEERCRED"), "Linux SO_PEERCRED required")
+class PeerCredentialTests(unittest.TestCase):
+    def test_kernel_reports_real_peer_and_ignores_request_identity(self):
+        left, right = socket.socketpair(socket.AF_UNIX)
+        try:
+            broker = status_broker.StatusBroker(
+                Path("/tmp/unused.sock"),
+                Path("/tmp/unused.json"),
+                {0},
+                {0},
+            )
+            _pid, uid, gid = broker.peer_identity(left)
+            self.assertGreaterEqual(uid, 0)
+            self.assertGreaterEqual(gid, 0)
+        finally:
+            left.close()
+            right.close()
+
+    def test_unauthorized_peer_causes_no_profile_or_network_access(self):
+        left, right = socket.socketpair(socket.AF_UNIX)
+        output = io.StringIO()
+        broker = status_broker.StatusBroker(
+            Path("/tmp/unused.sock"),
+            Path("/tmp/must-not-read.json"),
+            {999_999},
+            {999_999},
+        )
+        with (
+            patch("sys.stdout", output),
+            patch("status_broker.fetch_status") as fetch,
+        ):
+            broker.handle(left)
+        self.assertFalse(fetch.called)
+        audit = output.getvalue()
+        self.assertIn("unauthorized_peer", audit)
+        self.assertNotIn("credential", audit)
+        left.close()
+        right.close()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "bin/",
     "packages/cli/index.ts",
     "packages/client/index.ts",
+    "packages/client/broker.ts",
     "packages/mcp/index.ts",
     "packages/server/server.ts",
     "packages/server/transport.ts",
@@ -23,7 +24,7 @@
     "server": "bun run packages/server/server.ts",
     "typecheck": "tsc --noEmit",
     "test": "bun test",
-    "build": "bun build packages/cli/index.ts packages/client/index.ts packages/server/server.ts packages/mcp/index.ts --outdir dist --target bun",
+    "build": "bun build packages/cli/index.ts packages/client/index.ts packages/client/broker.ts packages/server/server.ts packages/mcp/index.ts --outdir dist --target bun",
     "verify:transport-v1": "bun test packages/server/transport.test.ts packages/mcp/index.test.ts packages/cli/security.test.ts"
   },
   "keywords": [

--- a/packages/cli/index.ts
+++ b/packages/cli/index.ts
@@ -10,6 +10,7 @@ import {
 import { homedir } from "os";
 import { dirname, join, resolve } from "path";
 import { randomUUID } from "crypto";
+import { requestStatusViaBroker } from "../client/broker";
 
 interface Config {
   server: string;
@@ -321,6 +322,19 @@ export async function runCli(): Promise<void> {
       break;
     }
     case "status": {
+      if (flag("broker-socket") && option("broker-socket") === undefined) {
+        throw new Error("usage: meshterm status --broker-socket /absolute/path");
+      }
+      const brokerSocket =
+        option("broker-socket") ?? process.env.MESHTERM_BROKER_SOCKET;
+      if (brokerSocket) {
+        print({
+          broker: "local",
+          metrics_scope: "authenticated_principal",
+          status: await requestStatusViaBroker(brokerSocket),
+        });
+        break;
+      }
       const config = loadConfig();
       const [ready, metrics] = await Promise.all([
         fetch(`${config.server}/readyz`).then((response) => response.json()),
@@ -503,7 +517,7 @@ Core:
   message <message-id>
   history [--limit n] [--cursor value]
   delete <message-id>  # sender only, after all deliveries are terminal
-  status
+  status [--broker-socket /absolute/path]
   principals
   channel list
   channel create <name> --members a,b

--- a/packages/cli/security.test.ts
+++ b/packages/cli/security.test.ts
@@ -185,3 +185,29 @@ describe("credential storage and Desktop integration", () => {
     ).toBe("work");
   });
 });
+
+describe("credentialless broker mode", () => {
+  test("does not load or fall back to a credential profile", () => {
+    const directory = tempDirectory();
+    const result = run(["status", "--broker-socket", "relative.sock"], {
+      MESHTERM_CONFIG_DIR: directory,
+    });
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr.toString()).toContain(
+      "broker socket must be an absolute path",
+    );
+    expect(result.stderr.toString()).not.toContain("config not found");
+  });
+
+  test("rejects a missing broker socket value without direct-mode fallback", () => {
+    const directory = tempDirectory();
+    const result = run(["status", "--broker-socket"], {
+      MESHTERM_CONFIG_DIR: directory,
+    });
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr.toString()).toContain(
+      "usage: meshterm status --broker-socket",
+    );
+    expect(result.stderr.toString()).not.toContain("config not found");
+  });
+});

--- a/packages/client/broker.test.ts
+++ b/packages/client/broker.test.ts
@@ -1,0 +1,192 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { createServer, type Server, type Socket } from "net";
+import { mkdtempSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import {
+  MeshtermBrokerError,
+  requestStatusViaBroker,
+  STATUS_BROKER_MAX_RESPONSE_BYTES,
+} from "./broker";
+
+const directories: string[] = [];
+const servers: Server[] = [];
+
+afterEach(async () => {
+  for (const server of servers.splice(0)) {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  }
+  for (const directory of directories.splice(0)) {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+async function fakeBroker(
+  responder: (request: Record<string, unknown>, socket: Socket) => void,
+): Promise<string> {
+  const directory = mkdtempSync(join(tmpdir(), "meshterm-broker-"));
+  directories.push(directory);
+  const path = join(directory, "status.sock");
+  const server = createServer((socket) => {
+    let text = "";
+    socket.on("data", (chunk) => {
+      text += chunk.toString("utf8");
+      if (text.endsWith("\n")) responder(JSON.parse(text), socket);
+    });
+  });
+  servers.push(server);
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(path, resolve);
+  });
+  return path;
+}
+
+function statusResponse(request: Record<string, unknown>) {
+  return {
+    version: 1,
+    request_id: request.request_id,
+    ok: true,
+    status: {
+      ready: true,
+      schema_version: 2,
+      journal_mode: "wal",
+      queue_depth: 0,
+      active_leases: 0,
+      acknowledged: 1,
+      dead_letters: 0,
+      discarded: 0,
+      retries: 0,
+      oldest_message_age_ms: 0,
+      average_delivery_latency_ms: 12.5,
+    },
+  };
+}
+
+describe("credentialless status broker client", () => {
+  test("sends only the closed v1 status request and validates the response", async () => {
+    const path = await fakeBroker((request, socket) => {
+      expect(Object.keys(request).sort()).toEqual([
+        "operation",
+        "request_id",
+        "version",
+      ]);
+      expect(request.operation).toBe("status");
+      expect(request.version).toBe(1);
+      socket.end(`${JSON.stringify(statusResponse(request))}\n`);
+    });
+    expect(await requestStatusViaBroker(path)).toMatchObject({
+      ready: true,
+      schema_version: 2,
+      acknowledged: 1,
+    });
+  });
+
+  test("rejects a mismatched request id", async () => {
+    const path = await fakeBroker((request, socket) => {
+      const response = statusResponse(request);
+      response.request_id = "different";
+      socket.end(`${JSON.stringify(response)}\n`);
+    });
+    await expect(requestStatusViaBroker(path)).rejects.toMatchObject({
+      code: "invalid_broker_response",
+    });
+  });
+
+  test("rejects unknown and duplicate fields", async () => {
+    const unknown = await fakeBroker((request, socket) => {
+      socket.end(
+        `${JSON.stringify({ ...statusResponse(request), extra: true })}\n`,
+      );
+    });
+    await expect(requestStatusViaBroker(unknown)).rejects.toBeInstanceOf(
+      MeshtermBrokerError,
+    );
+
+    const duplicate = await fakeBroker((request, socket) => {
+      const response = JSON.stringify(statusResponse(request));
+      socket.end(`${response.slice(0, -1)},"ok":true}\n`);
+    });
+    await expect(requestStatusViaBroker(duplicate)).rejects.toMatchObject({
+      code: "invalid_broker_response",
+    });
+  });
+
+  test("rejects malformed, oversized, and multiple responses", async () => {
+    const malformed = await fakeBroker((_request, socket) =>
+      socket.end("{bad json}\n"),
+    );
+    await expect(requestStatusViaBroker(malformed)).rejects.toMatchObject({
+      code: "invalid_broker_response",
+    });
+
+    const oversized = await fakeBroker((_request, socket) =>
+      socket.end(`${"x".repeat(STATUS_BROKER_MAX_RESPONSE_BYTES + 1)}\n`),
+    );
+    await expect(requestStatusViaBroker(oversized)).rejects.toMatchObject({
+      code: "invalid_broker_response",
+    });
+
+    const multiple = await fakeBroker((request, socket) => {
+      const response = JSON.stringify(statusResponse(request));
+      socket.end(`${response}\n${response}\n`);
+    });
+    await expect(requestStatusViaBroker(multiple)).rejects.toMatchObject({
+      code: "invalid_broker_response",
+    });
+  });
+
+  test("rejects negative, non-finite, and out-of-schema metrics", async () => {
+    const path = await fakeBroker((request, socket) => {
+      const response = statusResponse(request);
+      response.status.queue_depth = -1;
+      socket.end(`${JSON.stringify(response)}\n`);
+    });
+    await expect(requestStatusViaBroker(path)).rejects.toMatchObject({
+      code: "invalid_broker_response",
+    });
+  });
+
+  test("surfaces bounded broker errors without raw details", async () => {
+    const path = await fakeBroker((request, socket) =>
+      socket.end(
+        `${JSON.stringify({
+          version: 1,
+          request_id: request.request_id,
+          ok: false,
+          error: { code: "upstream_unavailable", message: "status is unavailable" },
+        })}\n`,
+      ),
+    );
+    await expect(requestStatusViaBroker(path)).rejects.toMatchObject({
+      code: "broker_rejected",
+      message: "status is unavailable",
+    });
+
+    const raw = await fakeBroker((request, socket) =>
+      socket.end(
+        `${JSON.stringify({
+          version: 1,
+          request_id: request.request_id,
+          ok: false,
+          error: { code: "unknown", message: "credential=must-not-surface" },
+        })}\n`,
+      ),
+    );
+    await expect(requestStatusViaBroker(raw)).rejects.toMatchObject({
+      code: "invalid_broker_response",
+      message: "broker returned an invalid response",
+    });
+  });
+
+  test("fails on unavailable sockets and timeouts", async () => {
+    await expect(
+      requestStatusViaBroker("/tmp/meshterm-definitely-missing.sock", 100),
+    ).rejects.toMatchObject({ code: "broker_unavailable" });
+
+    const path = await fakeBroker(() => {});
+    await expect(requestStatusViaBroker(path, 100)).rejects.toMatchObject({
+      code: "broker_timeout",
+    });
+  });
+});

--- a/packages/client/broker.ts
+++ b/packages/client/broker.ts
@@ -1,0 +1,304 @@
+import { randomUUID } from "crypto";
+import { createConnection } from "net";
+
+export const STATUS_BROKER_VERSION = 1 as const;
+export const STATUS_BROKER_MAX_REQUEST_BYTES = 512;
+export const STATUS_BROKER_MAX_RESPONSE_BYTES = 8_192;
+export const STATUS_BROKER_DEFAULT_TIMEOUT_MS = 3_000;
+
+export interface BrokerStatus {
+  ready: boolean;
+  schema_version: number;
+  journal_mode: string;
+  queue_depth: number;
+  active_leases: number;
+  acknowledged: number;
+  dead_letters: number;
+  discarded: number;
+  retries: number;
+  oldest_message_age_ms: number;
+  average_delivery_latency_ms: number;
+}
+
+export class MeshtermBrokerError extends Error {
+  constructor(
+    public readonly code:
+      | "broker_unavailable"
+      | "broker_timeout"
+      | "invalid_broker_response"
+      | "broker_rejected",
+    message: string,
+  ) {
+    super(message);
+    this.name = "MeshtermBrokerError";
+  }
+}
+
+const statusKeys = [
+  "ready",
+  "schema_version",
+  "journal_mode",
+  "queue_depth",
+  "active_leases",
+  "acknowledged",
+  "dead_letters",
+  "discarded",
+  "retries",
+  "oldest_message_age_ms",
+  "average_delivery_latency_ms",
+] as const;
+const brokerErrorMessages = {
+  unauthorized_peer: "peer is not authorized",
+  invalid_request: "request is invalid",
+  unsupported_version: "protocol version is unsupported",
+  profile_unavailable: "status profile is unavailable",
+  upstream_unavailable: "status is unavailable",
+  upstream_unauthorized: "status authorization failed",
+  invalid_upstream_response: "status response is invalid",
+  audit_unavailable: "audit is unavailable",
+  internal_error: "status is unavailable",
+} as const;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function hasExactKeys(
+  value: Record<string, unknown>,
+  expected: readonly string[],
+): boolean {
+  const actual = Object.keys(value).sort();
+  return (
+    actual.length === expected.length &&
+    [...expected].sort().every((key, index) => actual[index] === key)
+  );
+}
+
+function hasDuplicateObjectKeys(text: string): boolean {
+  const keys = [...text.matchAll(/"(?:\\.|[^"\\])*"\s*:/g)].map((match) =>
+    JSON.parse(match[0].replace(/\s*:$/, "")),
+  );
+  return new Set(keys).size !== keys.length;
+}
+
+function boundedInteger(value: unknown): value is number {
+  return (
+    typeof value === "number" &&
+    Number.isSafeInteger(value) &&
+    value >= 0 &&
+    value <= Number.MAX_SAFE_INTEGER
+  );
+}
+
+function boundedNumber(value: unknown): value is number {
+  return (
+    typeof value === "number" &&
+    Number.isFinite(value) &&
+    value >= 0 &&
+    value <= Number.MAX_SAFE_INTEGER
+  );
+}
+
+function validateStatus(value: unknown): BrokerStatus {
+  if (!isRecord(value) || !hasExactKeys(value, statusKeys)) {
+    throw new MeshtermBrokerError(
+      "invalid_broker_response",
+      "broker returned an invalid status response",
+    );
+  }
+  if (
+    typeof value.ready !== "boolean" ||
+    !boundedInteger(value.schema_version) ||
+    typeof value.journal_mode !== "string" ||
+    value.journal_mode.length < 1 ||
+    value.journal_mode.length > 16
+  ) {
+    throw new MeshtermBrokerError(
+      "invalid_broker_response",
+      "broker returned an invalid status response",
+    );
+  }
+  for (const key of statusKeys.slice(3, -1)) {
+    if (!boundedInteger(value[key])) {
+      throw new MeshtermBrokerError(
+        "invalid_broker_response",
+        "broker returned an invalid status response",
+      );
+    }
+  }
+  if (!boundedNumber(value.average_delivery_latency_ms)) {
+    throw new MeshtermBrokerError(
+      "invalid_broker_response",
+      "broker returned an invalid status response",
+    );
+  }
+  return value as unknown as BrokerStatus;
+}
+
+function parseResponse(text: string, requestId: string): BrokerStatus {
+  if (hasDuplicateObjectKeys(text)) {
+    throw new MeshtermBrokerError(
+      "invalid_broker_response",
+      "broker returned an invalid response",
+    );
+  }
+  let value: unknown;
+  try {
+    value = JSON.parse(text);
+  } catch {
+    throw new MeshtermBrokerError(
+      "invalid_broker_response",
+      "broker returned an invalid response",
+    );
+  }
+  if (!isRecord(value) || value.version !== STATUS_BROKER_VERSION) {
+    throw new MeshtermBrokerError(
+      "invalid_broker_response",
+      "broker returned an invalid response",
+    );
+  }
+  if (value.request_id !== requestId) {
+    throw new MeshtermBrokerError(
+      "invalid_broker_response",
+      "broker response did not match the request",
+    );
+  }
+  if (value.ok === true) {
+    if (!hasExactKeys(value, ["version", "request_id", "ok", "status"])) {
+      throw new MeshtermBrokerError(
+        "invalid_broker_response",
+        "broker returned an invalid response",
+      );
+    }
+    return validateStatus(value.status);
+  }
+  if (
+    value.ok === false &&
+    hasExactKeys(value, ["version", "request_id", "ok", "error"]) &&
+    isRecord(value.error) &&
+    hasExactKeys(value.error, ["code", "message"]) &&
+    typeof value.error.code === "string" &&
+    value.error.code in brokerErrorMessages &&
+    typeof value.error.message === "string" &&
+    value.error.code.length <= 64 &&
+    value.error.message.length <= 160
+  ) {
+    throw new MeshtermBrokerError(
+      "broker_rejected",
+      brokerErrorMessages[
+        value.error.code as keyof typeof brokerErrorMessages
+      ],
+    );
+  }
+  throw new MeshtermBrokerError(
+    "invalid_broker_response",
+    "broker returned an invalid response",
+  );
+}
+
+export function requestStatusViaBroker(
+  socketPath: string,
+  timeoutMs = STATUS_BROKER_DEFAULT_TIMEOUT_MS,
+): Promise<BrokerStatus> {
+  if (!socketPath.startsWith("/") || socketPath.length > 256) {
+    throw new MeshtermBrokerError(
+      "broker_unavailable",
+      "broker socket must be an absolute path",
+    );
+  }
+  if (!Number.isInteger(timeoutMs) || timeoutMs < 100 || timeoutMs > 30_000) {
+    throw new MeshtermBrokerError(
+      "broker_unavailable",
+      "broker timeout is invalid",
+    );
+  }
+  const requestId = randomUUID();
+  const request = `${JSON.stringify({
+    version: STATUS_BROKER_VERSION,
+    request_id: requestId,
+    operation: "status",
+  })}\n`;
+  if (Buffer.byteLength(request) > STATUS_BROKER_MAX_REQUEST_BYTES) {
+    throw new MeshtermBrokerError(
+      "broker_unavailable",
+      "broker request exceeds its size limit",
+    );
+  }
+
+  return new Promise((resolve, reject) => {
+    const socket = createConnection({ path: socketPath });
+    const chunks: Buffer[] = [];
+    let received = 0;
+    let settled = false;
+
+    const finish = (error?: Error, result?: BrokerStatus) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      socket.destroy();
+      if (error) reject(error);
+      else resolve(result!);
+    };
+    const timer = setTimeout(
+      () =>
+        finish(
+          new MeshtermBrokerError("broker_timeout", "broker request timed out"),
+        ),
+      timeoutMs,
+    );
+
+    socket.once("connect", () => socket.write(request));
+    socket.on("data", (chunk: Buffer) => {
+      received += chunk.length;
+      if (received > STATUS_BROKER_MAX_RESPONSE_BYTES) {
+        finish(
+          new MeshtermBrokerError(
+            "invalid_broker_response",
+            "broker response exceeds its size limit",
+          ),
+        );
+        return;
+      }
+      chunks.push(chunk);
+    });
+    socket.once("end", () => {
+      if (settled) return;
+      let text: string;
+      try {
+        text = new TextDecoder("utf-8", { fatal: true }).decode(
+          Buffer.concat(chunks),
+        );
+      } catch {
+        finish(
+          new MeshtermBrokerError(
+            "invalid_broker_response",
+            "broker returned an invalid response",
+          ),
+        );
+        return;
+      }
+      if (!text.endsWith("\n") || text.indexOf("\n") !== text.length - 1) {
+        finish(
+          new MeshtermBrokerError(
+            "invalid_broker_response",
+            "broker returned an invalid response",
+          ),
+        );
+        return;
+      }
+      try {
+        finish(undefined, parseResponse(text.slice(0, -1), requestId));
+      } catch (error) {
+        finish(error instanceof Error ? error : new Error("broker failed"));
+      }
+    });
+    socket.once("error", () =>
+      finish(
+        new MeshtermBrokerError(
+          "broker_unavailable",
+          "broker is unavailable",
+        ),
+      ),
+    );
+  });
+}


### PR DESCRIPTION
## Summary

- adds a host-neutral, versioned status-broker contract and credentialless CLI mode to Meshterm core
- keeps runtime-specific profile access, peer authorization, socket policy, audit, and deployment packaging in an isolated adapter
- documents the split architecture, threat model, migration, verification gates, and rollback boundaries

## Security boundaries

- supports only readiness and authenticated metrics for the fixed status operation
- enforces kernel peer identity, closed schemas, bounded input/output, time and rate limits, redirect refusal, filtered responses, and payload-free audit events
- provides no generic HTTP proxy, arbitrary command passthrough, or message lifecycle operations
- commits no credentials, profiles, queue data, payloads, or server state

## Verification

- typecheck passed
- 54 Bun tests passed with 176 assertions
- production build passed
- 14 adapter tests passed; two peer-credential cases were expectedly skipped on non-Linux local development
- reversible home-lab verification passed for credentialless status, Linux peer credentials, unsupported-operation rejection before network access, audit redaction, runtime health, and unchanged Transport v1 metrics baseline

## Rollback

The rollout remains reversible by removing the host CLI entry point and isolated broker sidecar/socket while preserving the independent known-good runtime status path. Rollback does not modify credentials, profiles, principals, queues, or server state.